### PR TITLE
(fix): Project pagination

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -235,6 +235,7 @@ func newEntry(c *api.Client, te dto.TimeEntryImpl, interactive, allowProjectByNa
 func getProjectID(projectID string, workspace string, c *api.Client) (string, error) {
 	projects, err := c.GetProjects(api.GetProjectsParam{
 		Workspace: workspace,
+		PaginationParam: api.PaginationParam{AllPages: true},
 	})
 
 	if err != nil {


### PR DESCRIPTION
If the user has more projects than fit into the first page, they can't create time entries for projects that are listed on a later page.

Need to fetch all pages when getting the list of projects.