### PR TITLE
Partial fix for issue #126: Get correct last entry when old api returns two

### DIFF
--- a/api/dto/dto.go
+++ b/api/dto/dto.go
@@ -263,14 +263,15 @@ type TimeEntriesList struct {
 
 // TimeEntryImpl DTO
 type TimeEntryImpl struct {
-	Billable     bool         `json:"billable"`
-	Description  string       `json:"description"`
-	ID           string       `json:"id"`
-	IsLocked     bool         `json:"isLocked"`
-	ProjectID    string       `json:"projectId"`
-	TagIDs       []string     `json:"tagIds"`
-	TaskID       string       `json:"taskId"`
-	TimeInterval TimeInterval `json:"timeInterval"`
-	UserID       string       `json:"userId"`
-	WorkspaceID  string       `json:"workspaceId"`
+	Billable         bool         `json:"billable"`
+	Description      string       `json:"description"`
+	ID               string       `json:"id"`
+	IsLocked         bool         `json:"isLocked"`
+	CurrentlyRunning bool         `json:"currentlyRunning"`
+	ProjectID        string       `json:"projectId"`
+	TagIDs           []string     `json:"tagIds"`
+	TaskID           string       `json:"taskId"`
+	TimeInterval     TimeInterval `json:"timeInterval"`
+	UserID           string       `json:"userId"`
+	WorkspaceID      string       `json:"workspaceId"`
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -544,8 +544,8 @@ func getTimeEntry(id, workspace, userID string, c *api.Client) (dto.TimeEntryImp
 	list, err := c.GetRecentTimeEntries(api.GetRecentTimeEntries{
 		Workspace:    workspace,
 		UserID:       userID,
-		Page:         1,
-		ItemsPerPage: 1,
+		Page:         0,
+		ItemsPerPage: 2,
 	})
 
 	if err != nil {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -566,7 +566,7 @@ func getFirstRunningEntry(list []dto.TimeEntryImpl, running bool) (dto.TimeEntry
 		}
 	}
 
-	return list[0], nil
+	return dto.TimeEntryImpl{}, errors.New("there is no previous time entry")
 }
 
 func addTimeEntryFlags(cmd *cobra.Command, withDates ...bool) {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -556,7 +556,17 @@ func getTimeEntry(id, workspace, userID string, c *api.Client) (dto.TimeEntryImp
 		return dto.TimeEntryImpl{}, errors.New("there is no previous time entry")
 	}
 
-	return list.TimeEntriesList[0], err
+	return getFirstRunningEntry(list.TimeEntriesList, id == "current")
+}
+
+func getFirstRunningEntry(list []dto.TimeEntryImpl, running bool) (dto.TimeEntryImpl, error) {
+	for _, entry := range list {
+		if entry.CurrentlyRunning == running {
+			return entry, nil
+		}
+	}
+
+	return list[0], nil
 }
 
 func addTimeEntryFlags(cmd *cobra.Command, withDates ...bool) {


### PR DESCRIPTION
This partially fixes the issue in #126 by ensuring the "current" and "last" keywords pull the correct time entry, since the old API can return 2 (despite the limit of 1).

In testing, this solves the issue with edit selecting the "last" rather than "current" entry, but the return still yields a 403 for me. I can confirm that directly hitting the api v1 403's for `GET https://api.clockify.me/api/v1/workspaces/<workspaceID>/time-entries/<timeEntryID>?hydrated=true`, but the `POST https://api.clockify.me/api/workspaces/<workspaceID>/timeEntries/<timeEntryID>` works.

Also, please let me now about any possible code improvements I could make to this as well. I'm still quite new with Golang.