### PR TITLE
feat: report today and yesterday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- new `report today` to show only the time entries from today, with `report` options
+- new `report yesterday` to show only the time entries from yesterday, with `report` options
+
 ### Fixed
 
 - golang commands were wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- golang commands were wrong
+- there was a output on report subcommands breaking the format
+
 ## [v0.27.1] - 2021-12-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `log` subcommand deprecated in favor of `report`
+- default `report` now allows to set only one date of the range, in this situation it will treat
+  start and end date as being the same.
+
 ### Added
 
 - new `report today` to show only the time entries from today, with `report` options

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -30,10 +30,11 @@ var dateFormat = "2006-01-02"
 
 // logCmd represents the log command
 var logCmd = &cobra.Command{
-	Use:     "log",
-	Aliases: []string{"logs"},
-	Short:   "List the entries from a specific day",
-	PreRunE: printMultipleTimeEntriesPreRun,
+	Use:        "log",
+	Aliases:    []string{"logs"},
+	Short:      "List the entries from a specific day",
+	Deprecated: "use report subcommands instead",
+	PreRunE:    printMultipleTimeEntriesPreRun,
 	RunE: withClockifyClient(func(cmd *cobra.Command, args []string, c *api.Client) error {
 		var filterDate time.Time
 

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -70,7 +69,7 @@ var reportLastMonthCmd = &cobra.Command{
 	}),
 }
 
-// reportThisWeekCmd represents the report last-month command
+// reportThisWeekCmd represents the report this-week command
 var reportThisWeekCmd = &cobra.Command{
 	Use:     "this-week",
 	Short:   "List all time entries in this week",
@@ -81,7 +80,7 @@ var reportThisWeekCmd = &cobra.Command{
 	}),
 }
 
-// reportLastWeekCmd represents the report last-month command
+// reportLastWeekCmd represents the report last-week command
 var reportLastWeekCmd = &cobra.Command{
 	Use:     "last-week",
 	Short:   "List all time entries in last week",
@@ -193,8 +192,6 @@ func getWeekRange(ref time.Time) (first, last time.Time) {
 }
 
 func reportWithRange(c *api.Client, start, end time.Time, cmd *cobra.Command) error {
-	fmt.Printf("%#v - %#v", start, end)
-
 	fillMissingDates, _ := cmd.Flags().GetBool("fill-missing-dates")
 	description, _ := cmd.Flags().GetString("description")
 

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -29,18 +29,22 @@ import (
 
 // reportCmd represents the reports command
 var reportCmd = &cobra.Command{
-	Use:     "report <start> <end>",
-	Short:   "List all time entries in the date ranges and with more data (format date as 2016-01-02)",
-	Args:    cobra.ExactArgs(2),
+	Use:     "report <start> [<end>]",
+	Short:   `List all time entries in the date ranges and with more data (format date as 2016-01-02)`,
+	Args:    cobra.RangeArgs(1, 2),
 	PreRunE: printMultipleTimeEntriesPreRun,
 	RunE: withClockifyClient(func(cmd *cobra.Command, args []string, c *api.Client) error {
 		start, err := time.Parse("2006-01-02", args[0])
 		if err != nil {
 			return err
 		}
-		end, err := time.Parse("2006-01-02", args[1])
-		if err != nil {
-			return err
+		end := start
+
+		if len(args) > 1 {
+			end, err = time.Parse("2006-01-02", args[1])
+			if err != nil {
+				return err
+			}
 		}
 
 		return reportWithRange(c, start, end, cmd)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -149,6 +149,28 @@ var reportLastWeekDayCmd = &cobra.Command{
 	}),
 }
 
+// reportToday represents report today command
+var reportToday = &cobra.Command{
+	Use:     "today",
+	Short:   "List all time entries created today",
+	PreRunE: printMultipleTimeEntriesPreRun,
+	RunE: withClockifyClient(func(cmd *cobra.Command, args []string, c *api.Client) error {
+		today := time.Now()
+		return reportWithRange(c, today, today, cmd)
+	}),
+}
+
+// reportYesterday represents report yesterday command
+var reportYesterday = &cobra.Command{
+	Use:     "yesterday",
+	Short:   "List all time entries created yesterday",
+	PreRunE: printMultipleTimeEntriesPreRun,
+	RunE: withClockifyClient(func(cmd *cobra.Command, args []string, c *api.Client) error {
+		yesterday := truncateDate(time.Now()).Add(-1)
+		return reportWithRange(c, yesterday, yesterday, cmd)
+	}),
+}
+
 func init() {
 	rootCmd.AddCommand(reportCmd)
 
@@ -163,6 +185,8 @@ func init() {
 	reportCmd.AddCommand(reportFlags(reportLastWeekCmd))
 	reportCmd.AddCommand(reportFlags(reportLastDayCmd))
 	reportCmd.AddCommand(reportFlags(reportLastWeekDayCmd))
+	reportCmd.AddCommand(reportFlags(reportToday))
+	reportCmd.AddCommand(reportFlags(reportYesterday))
 }
 
 func reportFlags(cmd *cobra.Command) *cobra.Command {


### PR DESCRIPTION
- Improvements to `report` command and subcommands.
- `log` now is **deprecated** in favor of `report` because it has options to do the same "queries"
