### PR TITLE
Use paginated call to find users.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dist: deps-install dist/darwin dist/linux dist/windows ## build all cli versions
 
 dist-internal:
 	mkdir -p dist/$(goos)
-	GOOS=$(goos) GOARCH=$(goarch) go build -o dist/darwin/clockify-cli $(MAIN_PKG)
+	GOOS=$(goos) GOARCH=$(goarch) go build -o dist/$(goos)/clockify-cli $(MAIN_PKG)
 
 dist/darwin:
 	make dist-internal goos=darwin goarch=amd64

--- a/api/client.go
+++ b/api/client.go
@@ -250,6 +250,8 @@ func (c *client) GetWorkspace(p GetWorkspace) (dto.Workspace, error) {
 type WorkspaceUsersParam struct {
 	Workspace string
 	Email     string
+
+	PaginationParam
 }
 
 // WorkspaceUsers all users in a Workspace
@@ -260,37 +262,25 @@ func (c *client) WorkspaceUsers(p WorkspaceUsersParam) (users []dto.User, err er
 		return users, err
 	}
 
-	r, err := c.NewRequest(
+	err = c.paginate(
 		"GET",
 		fmt.Sprintf("v1/workspaces/%s/users", p.Workspace),
-		nil,
+		PaginationParam{AllPages: true},
+		dto.WorkspaceUsersRequest{},
+		&users,
+		func(res interface{}) (int, error) {
+			if res == nil {
+				return 0, nil
+			}
+			ls := *res.(*[]dto.User)
+
+			users = append(users, ls...)
+			return len(ls), nil
+		},
+		"WorkspaceUsers",
 	)
-	if err != nil {
-		return users, err
-	}
 
-	_, err = c.Do(r, &users, "WorkspaceUsers")
-	if err != nil {
-		return users, err
-	}
-
-	if p.Email == "" {
-		return users, nil
-	}
-
-	uCopy := []dto.User{}
-	for i := 0; i < len(users); i++ {
-		if !strings.Contains(
-			strings.ToLower(users[i].Email),
-			strings.ToLower(p.Email),
-		) {
-			continue
-		}
-
-		uCopy = append(uCopy, users[i])
-	}
-
-	return uCopy, nil
+	return users, err
 }
 
 // PaginationParam parameters about pagination

--- a/api/client.go
+++ b/api/client.go
@@ -265,7 +265,7 @@ func (c *client) WorkspaceUsers(p WorkspaceUsersParam) (users []dto.User, err er
 	err = c.paginate(
 		"GET",
 		fmt.Sprintf("v1/workspaces/%s/users", p.Workspace),
-		PaginationParam{AllPages: true},
+		p.PaginationParam,
 		dto.WorkspaceUsersRequest{
 			Email: p.Email,
 		},

--- a/api/client.go
+++ b/api/client.go
@@ -266,7 +266,9 @@ func (c *client) WorkspaceUsers(p WorkspaceUsersParam) (users []dto.User, err er
 		"GET",
 		fmt.Sprintf("v1/workspaces/%s/users", p.Workspace),
 		PaginationParam{AllPages: true},
-		dto.WorkspaceUsersRequest{},
+		dto.WorkspaceUsersRequest{
+			Email: p.Email,
+		},
 		&users,
 		func(res interface{}) (int, error) {
 			if res == nil {

--- a/api/dto/request.go
+++ b/api/dto/request.go
@@ -410,6 +410,7 @@ type ChangeTimeEntriesInvoicedRequest struct {
 }
 
 type WorkspaceUsersRequest struct {
+	Email string
 	pagination
 }
 
@@ -417,4 +418,19 @@ type WorkspaceUsersRequest struct {
 func (r WorkspaceUsersRequest) WithPagination(page, size int) PaginatedRequest {
 	r.pagination = newPagination(page, size)
 	return r
+}
+
+// AppendToQuery decorates the URL with the query string needed for this Request
+func (r WorkspaceUsersRequest) AppendToQuery(u url.URL) url.URL {
+	u = r.pagination.AppendToQuery(u)
+
+	v := u.Query()
+
+	if r.Email != "" {
+		v.Add("email", r.Email)
+	}
+
+	u.RawQuery = v.Encode()
+
+	return u
 }

--- a/api/dto/request.go
+++ b/api/dto/request.go
@@ -408,3 +408,13 @@ type ChangeTimeEntriesInvoicedRequest struct {
 	TimeEntryIDs []string `json:"timeEntryIds"`
 	Invoiced     bool     `json:"invoiced"`
 }
+
+type WorkspaceUsersRequest struct {
+	pagination
+}
+
+// WithPagination add pagination to the WorkspaceUsersRequest
+func (r WorkspaceUsersRequest) WithPagination(page, size int) PaginatedRequest {
+	r.pagination = newPagination(page, size)
+	return r
+}

--- a/pkg/cmd/config/init/init.go
+++ b/pkg/cmd/config/init/init.go
@@ -67,7 +67,8 @@ func run(config cmdutil.Config, getClient func() (api.Client, error)) error {
 		strings.TrimSpace(workspace[0:strings.Index(workspace, " - ")]))
 
 	users, err := c.WorkspaceUsers(api.WorkspaceUsersParam{
-		Workspace: config.GetString(cmdutil.CONF_WORKSPACE),
+		Workspace:       config.GetString(cmdutil.CONF_WORKSPACE),
+		PaginationParam: api.AllPages(),
 	})
 
 	if err != nil {

--- a/pkg/cmd/user/user.go
+++ b/pkg/cmd/user/user.go
@@ -56,8 +56,9 @@ func NewCmdUser(f cmdutil.Factory) *cobra.Command {
 			}
 
 			users, err := c.WorkspaceUsers(api.WorkspaceUsersParam{
-				Workspace: w,
-				Email:     email,
+				Workspace:       w,
+				Email:           email,
+				PaginationParam: api.AllPages(),
 			})
 			if err != nil {
 				return err

--- a/pkg/cmdcomplutil/user.go
+++ b/pkg/cmdcomplutil/user.go
@@ -25,7 +25,8 @@ func NewUserAutoComplete(f factory) cmdcompl.SuggestFn {
 		}
 
 		us, err := c.WorkspaceUsers(api.WorkspaceUsersParam{
-			Workspace: w,
+			Workspace:       w,
+			PaginationParam: api.AllPages(),
 		})
 
 		if err != nil {

--- a/pkg/search/user.go
+++ b/pkg/search/user.go
@@ -17,7 +17,8 @@ func GetUsersByName(
 	}
 
 	us, err := c.WorkspaceUsers(api.WorkspaceUsersParam{
-		Workspace: workspace,
+		Workspace:       workspace,
+		PaginationParam: api.AllPages(),
 	})
 	if err != nil {
 		return users, err


### PR DESCRIPTION
Fixes https://github.com/lucassabreu/clockify-cli/issues/204

When there are more than 50 users, not all users show on the first page.
My user was below the fold, making the CLI unusable.
It checks if your user-id is in the list, but it would never be there.

This change forces the users call to do a paginated call
where it fetches all the pages.


**NB!** This PR also contains an unrelated change to the Makefile to ensure the binaries end up in the folder of their respective targets. I can take it out if you want. Let me know :slightly_smiling_face: 