### PR TITLE
fix: Request all pages when listing workspace users

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -745,7 +745,8 @@ func (c *client) GetUser(p GetUser) (dto.User, error) {
 	}
 
 	us, err := c.WorkspaceUsers(WorkspaceUsersParam{
-		Workspace: p.Workspace,
+		Workspace:       p.Workspace,
+		PaginationParam: AllPages(),
 	})
 	if err != nil {
 		return dto.User{}, errors.Wrapf(err, "get user %s", p.UserID)


### PR DESCRIPTION
In the rework on https://github.com/lucassabreu/clockify-cli/pull/205 (Related to https://github.com/lucassabreu/clockify-cli/issues/204) I missed (at least?) one call-site that should request all pages.