### PR TITLE
Fixed typo in configuring cli

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -11,7 +11,7 @@ related resources.
 
 - Generate a API key by visiting your user [settings on Clockify.me][settings], in the "API"
   section generate with you don't have one and copy your API key.
-- Run the command `clockify-cli config --init`, it will ask for the API key you copied.
+- Run the command `clockify-cli config init`, it will ask for the API key you copied.
   - The CLI will also ask for your preferences and default settings. You can change these
     preferences any time, see [clockify-cli config][cli-config] about the options.
 - After this run the command `clockify-cli in` to start a time entry.

--- a/site/content/usage/_index.md
+++ b/site/content/usage/_index.md
@@ -8,7 +8,7 @@ After you [install the CLI][install] the first thing to do is run the command `c
 init`, it will interactively ask you the information necessary to setup your environment.
 
 ```console
-$ clockify-cli config --init
+$ clockify-cli config init
 ? User Generated Token: <your-api-token>
 ? Choose default Workspace: <workspace-id> - John Doe's workspace
 ? Choose your user: <user-id> - John Doe


### PR DESCRIPTION
Changed `--init` to `init` in
- content/_index.md
- content/usage/_index.md