### PR TITLE
feat: Support for times without leading '0'

### DIFF
--- a/pkg/timehlp/time.go
+++ b/pkg/timehlp/time.go
@@ -7,11 +7,14 @@ import (
 )
 
 const (
-	FullTimeFormat        = "2006-01-02 15:04:05"
-	SimplerTimeFormat     = "2006-01-02 15:04"
-	OnlyTimeFormat        = "15:04:05"
-	SimplerOnlyTimeFormat = "15:04"
-	NowTimeFormat         = "now"
+	FullTimeFormat           = "2006-01-02 15:04:05"
+	SimplerTimeFormat        = "2006-01-02 15:04"
+	OnlyTimeFormat           = "15:04:05"
+	SimplerOnlyTimeFormat    = "15:04"
+	SimplerOnlyTimeFormatWL  = "5:04"
+	NowTimeFormat            = "now"
+	SimplestOnlyTimeFormat   = "1504"
+	SimplestOnlyTimeFormatWL = "504"
 )
 
 // ConvertToTime will try to convert a string do time.Time looking for the
@@ -44,27 +47,61 @@ func ConvertToTime(timeString string) (t time.Time, err error) {
 	if len(FullTimeFormat) != l &&
 		len(SimplerTimeFormat) != l &&
 		len(OnlyTimeFormat) != l &&
-		len(SimplerOnlyTimeFormat) != l {
+		len(SimplerOnlyTimeFormat) != l &&
+		len(SimplestOnlyTimeFormat) != l &&
+		len(SimplestOnlyTimeFormatWL) != l {
 		return t, fmt.Errorf(
 			"supported formats are: %s",
 			strings.Join(
 				[]string{
 					FullTimeFormat, SimplerTimeFormat, OnlyTimeFormat,
-					SimplerOnlyTimeFormat, NowTimeFormat,
+					SimplerOnlyTimeFormat, SimplerOnlyTimeFormatWL, NowTimeFormat,
+					SimplestOnlyTimeFormat, SimplestOnlyTimeFormatWL,
 				},
 				", ",
 			),
 		)
 	}
 
+	timeString = normalizeFormats(timeString)
+
+	return time.ParseInLocation(FullTimeFormat, timeString, time.Local)
+}
+
+// Adds data to the partial timeString to match a full
+// datetime with seconds precission.
+// Receives a time in any of the defined formats, and return
+// a date in the FullTimeFormat
+func normalizeFormats(timeString string) string {
+	l := len(timeString)
+
+	// change from 9:14 to 09:14
+	if len(SimplerOnlyTimeFormatWL) == l && strings.Contains(timeString, ":") {
+		timeString = "0" + timeString
+		l = l + 1
+	}
+
+	// change from 914 to 0914
+	if len(SimplestOnlyTimeFormatWL) == l && !strings.Contains(timeString, ":") {
+		timeString = "0" + timeString
+		l = l + 1
+	}
+
+	// change from 0914 to 09:14
+	if len(SimplestOnlyTimeFormat) == l {
+		timeString = timeString[0:2] + ":" + timeString[2:]
+		l = l + 1
+	}
+
+	// change from 09:14 to 09:14:00
 	if len(SimplerOnlyTimeFormat) == l || len(SimplerTimeFormat) == l {
 		timeString = timeString + ":00"
 		l = l + 3
 	}
 
+	// change from 09:14 to 2006-01-02 09:14:00
 	if len(OnlyTimeFormat) == l {
 		timeString = Today().Format("2006-01-02") + " " + timeString
 	}
-
-	return time.ParseInLocation(FullTimeFormat, timeString, time.Local)
+	return timeString
 }

--- a/pkg/timehlp/time_test.go
+++ b/pkg/timehlp/time_test.go
@@ -1,0 +1,50 @@
+package timehlp_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lucassabreu/clockify-cli/pkg/timehlp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTime(t *testing.T) {
+
+	now := timehlp.Today()
+	nowStr := now.Format("2006-01-02")
+
+	t.Run("now", func(t *testing.T) {
+		// this case is special because it is not deterministic
+		parsed, err := timehlp.ConvertToTime("now")
+
+		assert.Nil(t, err)
+		assert.Equal(t, nowStr, parsed.Format("2006-01-02"))
+
+	})
+
+	tts := []struct {
+		name     string
+		expected string
+		toParse  string
+	}{
+		{name: "FullTimeFormat", expected: "09:59:01", toParse: fmt.Sprintf("%s %s", nowStr, "09:59:01")},
+		{name: "SimplerTimeFormat", expected: "09:59:00", toParse: fmt.Sprintf("%s %s", nowStr, "09:59")},
+		{name: "OnlyTimeFormat", expected: "16:03:02", toParse: "16:03:02"},
+		{name: "SimplerOnlyTimeFormat", expected: "16:03:00", toParse: "16:03"},
+		{name: "SimplerOnlyTimeFormat", expected: "06:03:00", toParse: "06:03"},
+		{name: "SimplerOnlyTimeFormatWL", expected: "06:03:00", toParse: "6:03"},
+		{name: "SimplestOnlyTimeFormat", expected: "16:03:00", toParse: "1603"},
+		{name: "SimplestOnlyTimeFormatWL", expected: "06:03:00", toParse: "603"},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+
+			parsed, err := timehlp.ConvertToTime(tt.toParse)
+
+			assert.Nil(t, err)
+			assert.Equal(t, fmt.Sprintf("%s %s", nowStr, tt.expected), parsed.Format("2006-01-02 15:04:05"))
+		})
+	}
+
+}


### PR DESCRIPTION
The web interface of clockify supports times in format `HMM` (1 digit for the hour and 2 digits for the minutes), for example `915` is `09:15`.

I am not very familiar with go, but I added a test (following another test in this repo) to make sure everything works.

To check the new test use`go test -v pkg/timehlp/time_test.go`.

The parser now also supports the format `H:MM` also is supported by the web interface, to keep the names short the suffix 'WL' was used (without leading 0, suggestions welcome!).