### PR TITLE
fix: update link to API key generator

### DIFF
--- a/pkg/cmd/config/init/init.go
+++ b/pkg/cmd/config/init/init.go
@@ -41,9 +41,8 @@ func NewCmdInit(f cmdutil.Factory) *cobra.Command {
 			token := ""
 			if token, err = i.AskForText("User Generated Token:",
 				ui.WithDefault(config.GetString(cmdutil.CONF_TOKEN)),
-				ui.WithHelp("Can be generated in the following like, "+
-					"in the API section: "+
-					"https://clockify.me/user/settings#generateApiKeyBtn"),
+				ui.WithHelp("Can be generated at "+
+					"https://app.clockify.me/manage-api-keys"),
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
This updates the help message for the `config init` dialog. The old link did result in 404.