### PR TITLE
Add configurable Clockify API base URL

### DIFF
--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -39,6 +39,7 @@ var validParameters = cmdcompl.ValidArgsMap{
 	cmdutil.CONF_LANGUAGE: "which language to use for number " +
 		"formatting",
 	cmdutil.CONF_TIMEZONE: "which timezone to use to input/output time",
+	cmdutil.CONF_API_URL:  "custom Clockify API base URL (for segregated tenants)",
 }
 
 // NewCmdConfig represents the config command

--- a/pkg/cmdutil/config.go
+++ b/pkg/cmdutil/config.go
@@ -32,6 +32,7 @@ const (
 	CONF_INTERACTIVE_PAGE_SIZE            = "interactive-page-size"
 	CONF_LANGUAGE                         = "lang"
 	CONF_TIMEZONE                         = "time-zone"
+	CONF_API_URL                          = "api-url"
 )
 
 const (

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -181,7 +181,15 @@ func clientFunc(f Factory) func() (api.Client, error) {
 			return c, err
 		}
 
-		c, err = api.NewClient(f.Config().GetString(CONF_TOKEN))
+		apiUrl := f.Config().GetString(CONF_API_URL)
+		if apiUrl != "" {
+			c, err = api.NewClientFromUrlAndKey(
+				f.Config().GetString(CONF_TOKEN),
+				apiUrl,
+			)
+		} else {
+			c, err = api.NewClient(f.Config().GetString(CONF_TOKEN))
+		}
 		if err != nil {
 			return c, err
 		}


### PR DESCRIPTION
Added a simple config option to allow the cli to work on segregated tenants (as requested in https://github.com/lucassabreu/clockify-cli/issues/284).

To do this you simply need to run
`clockify-cli config set api-url <YOUR_TENANT>`

Where <YOUR_TENANT> is typically something like `https://YOURORGANIZATION.clockify.me/api`